### PR TITLE
Exports types from `@omotes/proto`.

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,3 +1,5 @@
+export * from '@omotes/proto';
+
 export * from './lib/Job';
 export * from './lib/OmotesSDK';
 export * from './lib/channel';
@@ -5,4 +7,3 @@ export * from './lib/handlers/ProgressHandler';
 export * from './lib/handlers/ResultHandler';
 export * from './lib/handlers/StatusHandler';
 export * from './lib/types';
-


### PR DESCRIPTION
Fixes #4.