### PR TITLE
Set a default timeout of 2 hours.

### DIFF
--- a/sdk/src/lib/Job.spec.ts
+++ b/sdk/src/lib/Job.spec.ts
@@ -88,6 +88,12 @@ describe('Job', () => {
       expect(() => job.setParams({}).setJobReference('')).not.toThrow();
     });
   });
+
+  describe('timeout', () => {
+    it('should default to two hours', () => {
+      expect(getSubmissionFromJob(job).getTimeoutMs()).toBe(1000 * 60 * 60 * 2);
+    });
+  });
 });
 
 function getSubmissionFromJob(job: Job) {

--- a/sdk/src/lib/Job.ts
+++ b/sdk/src/lib/Job.ts
@@ -25,7 +25,7 @@ export class Job {
     this.jobSubmission.setUuid(this.uuid);
     this.jobSubmission.setWorkflowType(type);
     this.jobSubmission.setEsdl(this.esdl);
-    this.jobSubmission.setTimeoutMs(0);
+    this.jobSubmission.setTimeoutMs(1000 * 60 * 60 * 2); // for now, hard code two hours.
   }
 
   public start() {

--- a/sdk/src/lib/handlers/ResultHandler.spec.ts
+++ b/sdk/src/lib/handlers/ResultHandler.spec.ts
@@ -28,7 +28,8 @@ describe('ResultsHandler', () => {
           uuid: 'uuid',
           logs: 'logs',
           outputEsdl: 'output_esdl',
-          resultType: JobResult.ResultType.SUCCEEDED
+          resultType: JobResult.ResultType.SUCCEEDED,
+          esdlMessagesList: [],
         });
         done();
       });


### PR DESCRIPTION
Temporarily fixes #35.

We'll need to update to `protoc-gen-ts` to create messages that omit undefined values in their binary representation.